### PR TITLE
Renamed "demo" to "examples" in contrib doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 ## Demo Development Server
 
-* `cd demo && npm install` to install dependencies for the sample page
+* `cd examples && npm install` to install dependencies for the sample page
 * `npm start` will run a development server with the component's demo app at [http://localhost:9966](http://localhost:9966) with hot module reloading.
 
 ## Running Tests


### PR DESCRIPTION
The `demo` folder was moved over to `examples` recently.