### PR TITLE
Fixes the 'getskeleton' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ extras
 - `glamor/jsxstyle` - [react integration](https://github.com/threepointone/glamor/blob/master/docs/jsxstyle.md), à la [jsxstyle](https://github.com/petehunt/jsxstyle/)
 - `glamor/aphrodite` - [shim](https://github.com/threepointone/glamor/blob/master/docs/aphrodite.md) for [aphrodite](https://github.com/Khan/aphrodite) stylesheets
 - `glamor/utils` - a port of [postcss-utilities](https://github.com/ismamz/postcss-utilities)
-- `glamor/ous` - a port of [the skeleton css framework](getskeleton.com)
+- `glamor/ous` - a port of [the skeleton css framework](http://getskeleton.com)
 
 
 characteristics


### PR DESCRIPTION
The current link goes out to a 404 on github.