### PR TITLE
On insert, return an updateRule method

### DIFF
--- a/src/sheet.js
+++ b/src/sheet.js
@@ -87,7 +87,7 @@ export class StyleSheet {
           // in other words, just the cssText field
           const serverRule = { cssText: rule }
           this.sheet.cssRules.push(serverRule)
-          return {serverRule, updateRule: (newCss => serverRule.cssText = newCss)}
+          return {serverRule, appendRule: (newCss => serverRule.cssText += newCss)}
         }
       }
     }
@@ -128,7 +128,7 @@ export class StyleSheet {
       else{
         const textNode = document.createTextNode(rule)
         last(this.tags).appendChild(textNode)
-        insertedRule = { textNode, updateRule: newCss => (textNode.data = newCss)}
+        insertedRule = { textNode, appendRule: newCss => textNode.appendData(newCss)}
 
         if(!this.isSpeedy) {
           // sighhh


### PR DESCRIPTION
This is to support the changes needed for https://github.com/styled-components/styled-components/pull/31

We need to preserve the order of instantiation of each rule we insert, so that we always render them consistently. Relying on react's rendering isn't sufficient, sadly. So we inject an empty rule, then call `updateRule` on the return value every time we have something new.

This isn't quite ready to be merged, you'd probably want to clean it up and make sure `insertRule` has an equivalent return method. But thought you might be interested to see what I ended up doing to get it working.
