### PR TITLE
import app from right path

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,5 +1,5 @@
 import React from 'react' //eslint-disable-line
 import { render } from 'react-dom'
-import { App } from './classes'
+import { App } from './tweet'
 render(<App/>,
   document.querySelector('#demo'))


### PR DESCRIPTION
Looks like the import path was changed from `tweet` to `classes` here 92ffdb43eedc017575d045162caa94d1d4471b99 which breaks the example app. Is this the right way to do? Or change the folder name to `classes`?