### PR TITLE
Add support for CSS custom properties

### DIFF
--- a/src/CSSPropertyOperations/index.js
+++ b/src/CSSPropertyOperations/index.js
@@ -118,16 +118,21 @@ if (process.env.NODE_ENV !== 'production') {
 export function createMarkupForStyles(styles, component) {
   let serialized = ''
   for (let styleName in styles) {
+    const isCustomProp = styleName.startsWith('--');
     if (!styles.hasOwnProperty(styleName)) {
       continue
     }
     let styleValue = styles[styleName]
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' && !isCustomProp) {
       warnValidStyle(styleName, styleValue, component)
     }
     if (styleValue != null) {
-      serialized += processStyleName(styleName) + ':'
-      serialized += dangerousStyleValue(styleName, styleValue, component) + ';'
+      if (isCustomProp) {
+        serialized += `${styleName}:${styleValue};`
+      } else {
+        serialized += processStyleName(styleName) + ':'
+        serialized += dangerousStyleValue(styleName, styleValue, component) + ';'
+      }
     }
   }
   return serialized || null

--- a/tests/index.js
+++ b/tests/index.js
@@ -31,6 +31,8 @@ import clean from '../src/clean'
 
 import { View } from '../src/jsxstyle'
 
+import { createMarkupForStyles } from '../src/CSSPropertyOperations'
+
 function childStyle(node, p = null) {
   return window.getComputedStyle(node.childNodes[0], p)
 }
@@ -503,6 +505,13 @@ describe('clean', () => {
       expect(clean(sample)).toBe(null)
     })
   })
+
+  it('handles css variables', () => {
+    expect(createMarkupForStyles({'--myVar': 'value'})).toEqual('--myVar:value;');
+    expect(createMarkupForStyles({'--my-var': 'value'})).toEqual('--my-var:value;');
+    expect(createMarkupForStyles({'--myVar': 'value', fontSize: 20})).toEqual('--myVar:value;font-size:20px;');
+  })
+
 })
 
 describe('empty styles', () => {  


### PR DESCRIPTION
CSS custom properties, also called CSS variables, are property names
prefixed with `--`. In that case, don't process the property name, nor
the value, and add them as they are.

Now the property name is converted from camel case to kebab case and `px` is appended to the value if it is a number. E.g.:
```
style({'--myVar': 50})
```

is converted to `--my-var:50px;`, when it should be `--myVar:50;`

I created this jsbin where you can test it:
https://jsbin.com/mijixu/6/edit?html,output