### PR TITLE
Add failing test for shorthand/longhand merge

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -112,6 +112,29 @@ describe('glamor', () => {
     
   })
 
+  it('shorthand styles can be combined with long form', () => {
+
+    // when you need fine grained control over which keys get prcedence,
+    // manually merge your styles together
+    render(<div {...style({
+            boxSizing: 'border-box',
+            borderWidth: 0,
+            borderStyle: 'solid',
+            background: 'blue',
+            padding: 0,
+            font: 'inherit',
+            textTransform: 'inherit',
+            textDecoration: 'none',
+            left: 5,
+          }, {
+            fontSize: 50,
+          } )} />, node, () => {
+      expect(childStyle(node).fontSize).toEqual('50px');
+    })
+
+    
+  })
+
   it('accepts nested objects', () => {
     simulations(true)
     render(<div {...style({ 


### PR DESCRIPTION
Adds a test that fails in Chrome and succeeds in Phantom when
combining shorthand and longhand properties. The bug seems to be
ordering-related as the shorthand `font` appears at the bottom of the
declared styles even though it is declared in the first glamor style
object.