### PR TITLE
Add support for properly transpiling with babel.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": [ [ "es2015", { "modules": false } ], "stage-0", "react" ],
-  plugins: [ "transform-decorators-legacy" ]
+  "plugins": [ "transform-decorators-legacy", "transform-runtime" ]
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-plugin-istanbul": "^3.0.0",
     "babel-plugin-react-require": "^3.0.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-polyfill": "^6.16.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
@@ -112,6 +112,7 @@
     }
   },
   "dependencies": {
-    "fbjs": "^0.8.6"
+    "fbjs": "^0.8.6",
+    "babel-polyfill": "^6.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -113,6 +113,6 @@
   },
   "dependencies": {
     "fbjs": "^0.8.6",
-    "babel-polyfill": "^6.16.0"
+    "babel-runtime": "^6.18.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,6 +841,12 @@ babel-plugin-transform-regenerator@^6.16.0:
     babel-types "^6.16.0"
     private "~0.1.5"
 
+babel-plugin-transform-runtime@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.15.0.tgz#3d75b4d949ad81af157570273846fb59aeb0d57c"
+  dependencies:
+    babel-runtime "^6.9.0"
+
 babel-plugin-transform-strict-mode@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz#df7cf2991fe046f44163dcd110d5ca43bc652b9d"
@@ -950,6 +956,13 @@ babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.2.0, babel-runtime
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.9.5"
+
+babel-runtime@^6.18.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
 
 babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.3.0, babel-template@^6.8.0:
   version "6.16.0"
@@ -4610,6 +4623,10 @@ redent@^1.0.0:
 regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
+
+regenerator-runtime@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz#257f41961ce44558b18f7814af48c17559f9faeb"
 
 regenerator-runtime@^0.9.5:
   version "0.9.6"


### PR DESCRIPTION
Fixes #155 
Also fixes https://github.com/zeit/next.js/issues/473

This adds support transform-runtime support for babel.
So it'll take polyfills from core-js and works on older browsers too.