### PR TITLE
Dont append hash ID to custom animation names.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -237,8 +237,6 @@ function toRule(spec) {
     return ruleCache[spec.id]
   }
 
-  
-
   let ret = { [`data-css-${spec.id}`]: hasLabels ? spec.label || '' : '' }
   Object.defineProperty(ret, 'toString', {
     enumerable: false, value() { return 'css-' + spec.id }
@@ -365,8 +363,6 @@ function build(dest, { selector = '', mq = '', supp = '', src = {} }) {
     })  
   }) 
 }
-
-
 
 function _css(rules) {
   let style = { label: [] }
@@ -500,7 +496,13 @@ css.keyframes = (name, kfs) => {
   }
   register(spec)
   insertKeyframe(spec)
-  return name + '_' + spec.id
+
+  // only append id if a name was not provided
+  if (name === 'animation') {
+    return name + '_' + spec.id
+  }
+
+  return name
 }
 
 
@@ -801,4 +803,3 @@ export function attribsFor(...rules) {
 
   return htmlAttributes
 }
-

--- a/tests/index.js
+++ b/tests/index.js
@@ -428,8 +428,18 @@ describe('glamor', () => {
       })
       expect(styleSheet.rules()[0].cssText.replace(/\s/g,''))
         .toEqual('@-webkit-keyframesbounce_zhy6v5{0%{-webkit-transform:scale(0.1);opacity:0;}60%{-webkit-transform:scale(1.2);opacity:1;}100%{-webkit-transform:scale(1);}}')
-      expect(animate).toEqual('bounce_zhy6v5')
+      expect(animate).toEqual('bounce')
 
+    })
+
+    it('will autocreate an animation name', () => {
+      let animate = css.keyframes({
+        '0%': { opacity: 0 },
+        '100%': { opacity: 1 }
+      })
+      expect(styleSheet.rules()[0].cssText.replace(/\s/g,''))
+        .toEqual('@-webkit-keyframesanimation_15qjrhp{0%{opacity:0;}100%{opacity:1;}}')
+      expect(animate).toEqual('animation_15qjrhp')
     })
   }
 


### PR DESCRIPTION
This minor change will avoid appending an ID to an animation name (if it was provided as the 1st argument). This is quite useful as `animationName: fade` can simply be used without having to use interpolation to inject the name.