### PR TITLE
Restrict CSSProperties type to use the CSSProperties from React

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
-export interface CSSProperties {
+import * as React from 'react';
+
+export type CSSProperties = React.CSSProperties & {
   /**
    * In dev mode, adding a `label` string prop will reflect its value in devtools. Useful
    * when debugging, and a good alternative to 'semantic' classnames.
    */
   label?: string;
-  // for now just allow everything
-  [propertyName: string]: any;
-}
+};
 
 export interface StyleAttribute {
   [attributeName: string]: '';


### PR DESCRIPTION
This ultimately allows autocompletion of css properties when using glamor functions
that takes `CSSProperties` as input, unfortunately it does not work with the `css` function yet
I think it has to do with the pretty loose input definition with too many possible outcomes
but I will look into that.

For every other functions which only takes `CSSProperties` as input
you get nice autocompletion.

Disclaimer: this only works with TypeScript 2.1+ if that is okay.

This has a pretty big downside, because `index.d.ts` now has a dependency to `react`
but I saw you had react as a dependency in `package.json` but only as a devDependency,
so you'll have to consider if you want to do this.

The feature of MappedTypes is described here:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html