### PR TITLE
remove unnecessary glamor dependency in v3 migration

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -26,7 +26,6 @@ The following diff shows the migration from `glamor/react` to `glamor-react`, bu
   "name": "your-project",
   "dependencies": {
 -    "glamor": "^2.0.0"
-+    "glamor": "^3.0.0",
 +    "glamor-react": "^3.0.0"
   }
 }


### PR DESCRIPTION
A change to the migration doc because the `glamor-react` [re-exports all of glamor](https://github.com/threepointone/glamor/blob/1ce8d77afc489a012a2b0bdc851de050ec8535da/packages/glamor-react/src/index.js#L5), thus making an explicit dependency on `glamor` in a user's app's package.json unnecessary.
