### PR TITLE
Remove media-query presets from core

### DIFF
--- a/packages/glamor-jsxstyle/tests/index.js
+++ b/packages/glamor-jsxstyle/tests/index.js
@@ -22,7 +22,7 @@ describe('glamor-jsxstyle', () => {
                backgroundColor="#ccc"
                hover={{ color: 'blue' }}
                select={[ ' li', { textDecoration: 'underline' } ]}
-               media={[ presets.mobile, { color: 'green' } ]}
+               media={[ '(min-width: 400px)', { color: 'green' } ]}
                style={{ outline: '1px solid black' }}
                className="myView"
                onClick={() => console.log('whutwhut')} // eslint-disable-line no-console

--- a/packages/glamor/src/index.js
+++ b/packages/glamor/src/index.js
@@ -553,19 +553,6 @@ export function flush() {
 
 }
 
-export const presets = {
-  mobile : '(min-width: 400px)',
-  Mobile: '@media (min-width: 400px)',
-  phablet : '(min-width: 550px)',
-  Phablet : '@media (min-width: 550px)',
-  tablet : '(min-width: 750px)',
-  Tablet : '@media (min-width: 750px)',
-  desktop : '(min-width: 1000px)',
-  Desktop : '@media (min-width: 1000px)',
-  hd : '(min-width: 1200px)',
-  Hd : '@media (min-width: 1200px)'
-}
-
 export const style = css
 
 export function select(selector, ...styles) {

--- a/packages/glamor/tests/index.js
+++ b/packages/glamor/tests/index.js
@@ -21,7 +21,6 @@ import { style, hover, nthChild, firstLetter, media, merge, compose,  select, vi
   cssLabels,
   simulations, simulate,
   cssFor, attribsFor, idFor,
-  presets,
   flush, styleSheet, rehydrate, css }
 from '../src'
 


### PR DESCRIPTION
They should exist in "css framework" or utils type packages instead.

Addresses @donaldpipowitch's comment here: https://github.com/threepointone/glamor/issues/83#issuecomment-281660522