### PR TITLE
Fixed typo in "howto" doc

### DIFF
--- a/docs/howto.md
+++ b/docs/howto.md
@@ -260,7 +260,7 @@ const container = css(
     clear: 'both'
   }),
   { 
-    '@media('(min-width: 400px)': {
+    '@media(min-width: 400px)': {
       width: '85%',
       padding: 0
     }


### PR DESCRIPTION
There are extra quotation mark and parenthesis, which breaks media queries example. Fixed :thumbsup: