### PR TITLE
Using the docs suggested way to render on the server side, content: "" in ::before, ::after gets encoded as &quote;

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -21,7 +21,11 @@ let { html, css, ids } = renderStatic(() =>
 <!-- when rendering your html -->
 <html>
   <head>
-    <style>${css}</style>
+    <!-- to avoid certain characters getting encoded
+      as html entities (like quotes in css 'content' property),
+      we use dangerouslySetInnerHTML to inject our css
+    -->
+    <style dangerouslySetInnerHTML={{ __html: css }} />
     <!-- alternately, you'd save the css to a file
       and include it here with
     <link rel='stylesheet' href='path/to/css'/>

--- a/docs/server.md
+++ b/docs/server.md
@@ -26,7 +26,7 @@ let { html, css, ids } = renderStatic(() =>
       we use dangerouslySetInnerHTML to inject our css
     -->
     <style dangerouslySetInnerHTML={{ __html: css }} />
-    <!-- alternately, you'd save the css to a file
+    <!-- alternatively, you'd save the css to a file
       and include it here with
     <link rel='stylesheet' href='path/to/css'/>
      -->


### PR DESCRIPTION
Suppose we have:

`css = '.css-abc:before { content: "" }'`

then:

`<style>{css}</style>`

gives:

`<style>.css-abc:before { content: &quot;&quot; } </style>`

... which is not the desired outcome. Whereas:

`<style dangerouslySetInnerHTML={{ __html: css }} />`

will give:

`<style>.css-abc:before { content: "" } </style>`

Updating docs/server.md so others aren't misled.