### PR TITLE
inject with prepend distinction

### DIFF
--- a/packages/glamor/tests/prepend.js
+++ b/packages/glamor/tests/prepend.js
@@ -1,0 +1,20 @@
+import { StyleSheet } from '../src/sheet';
+import expect from 'expect'
+
+describe('StyleSheet prepend', () => {
+  it('can initialize in prepend mode', () => {
+    // insert a style tag that isn't glamor (cssmodules or something)
+    let tag = document.createElement('style');
+    tag.type = 'text/css';
+    tag.setAttribute('data-is-css-modules', '')
+    tag.appendChild(document.createTextNode(''));
+    (document.head || document.getElementsByTagName('head')[0]).appendChild(tag);
+
+    let sheet = new StyleSheet();
+    sheet.inject({ prepend: true });
+    expect([ ...document.styleSheets ].filter(s => s.ownerNode === sheet.tags[0]).length).toEqual(1);
+    expect([ ...document.styleSheets ].findIndex(s => s.ownerNode === sheet.tags[0])).toEqual(0);
+      expect(sheet.tags[0].hasAttribute('data-glamor')).toEqual(true)
+    sheet.flush();
+  })
+})


### PR DESCRIPTION
This is for discussion of #235. Namely, adding the ability to configure glamor in "prepend" mode, which adds a style tag at the beginning of the `<head>` instead of at the end. This is useful for using glamor in combination with other technologies where glamor is used as the CSS reset and should be before the other stylesheet at development and production times.

This PR adds a test to sheet.js to support prepending and satisfies that test, but does not currently move that functionality forward into the glamor import, which currently automatically `inject()`'s.

Notable work that would still have to happen includes:

* [dealing with configuring the automatic injection](https://github.com/threepointone/glamor/blob/e38b0dbd6ebdfde9876c2aba2df3868728d0de07/packages/glamor/src/index.js#L11)
* [dealing with flushing appropriately](https://github.com/threepointone/glamor/blob/e38b0dbd6ebdfde9876c2aba2df3868728d0de07/packages/glamor/src/index.js#L547) (perhaps by adding an option to that function call as well).

Open to opinions on how best to accomplish the two items above if this direction is desirable.