### PR TITLE
Remove CommonJS call

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -46,7 +46,7 @@ export function fallbacks(node) {
   return node   
 }
 
-const prefixAll = require('./inline-style-prefix-all/index.js')
+import prefixAll from './inline-style-prefix-all'
 
 export function prefixes(node) {
   return assign({}, node, { style: prefixAll(node.style) })


### PR DESCRIPTION
Because of this: rollup/rollup-plugin-commonjs#96 Glamor's es6 build isn't importable into a Rollup build. Just ran into this now.

This should fix things up, and also better follows the [unambiguous grammar proposal](https://github.com/nodejs/node-eps/blob/master/002-es6-modules.md#51-determining-if-source-is-an-es-module). (Yes, I know they're going with .mjs, but this still fits with the right spirit of the spec)