### PR TITLE
Include ids for keyframes and fontFace in ids from renderStaticOptimized

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -43,7 +43,7 @@ export function renderStaticOptimized(fn) {
     }
     return false
   })
-  o.ids = Object.keys(styleSheet.inserted).filter(id => !!ids[id + ''] || styleSheet.registered[id].type === 'raw')
+  o.ids = Object.keys(styleSheet.inserted).filter(id => !!ids[id + ''] || styleSheet.registered[id].type === 'raw' ||  styleSheet.registered[id].type === 'keyframes' || styleSheet.registered[id].type === 'font-face')
   o.css = o.rules.map(x => x.cssText).join('')
 
   return o


### PR DESCRIPTION
This does the same thing as tkh44/emotion#218.

This adds the ids for `keyframes` and `fontFace` to the `ids` returned from `renderStaticOptimized` so they're not reinserted on the client.