### PR TITLE
Add support for babel-macros

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": [ [ "env", { "modules": false } ], "stage-0", "react" ],
-  "plugins": [ "transform-decorators-legacy" ]
+  "plugins": [ "transform-decorators-legacy" , "babel-macros" ]
 }

--- a/examples/css.js
+++ b/examples/css.js
@@ -1,7 +1,7 @@
 // inline css prop
 
 import React from 'react'
-import { cssFor, css } from 'glamor'
+import { css } from '../src/macro'
 
 function log(x) {
   console.log((x || ''), this) // eslint-disable-line no-console
@@ -35,7 +35,7 @@ let rule = css`
     color: orange;
     height:100vh;
     width: 300;
-    
+
     border: ${1}px ${'solid'} blue;
     ${{ color: 'brown' }}
     && {
@@ -46,6 +46,6 @@ let rule = css`
   margin: 0
 `
 
-export const App = () => <div className={rule}>
+export const App = () => <div className={css`${rule}; font-size: 10em`}>
   ...
 </div>

--- a/examples/css.js
+++ b/examples/css.js
@@ -1,7 +1,7 @@
 // inline css prop
 
 import React from 'react'
-import { css } from '../src/macro'
+import { css as cssFoo } from '../src/macro'
 
 function log(x) {
   console.log((x || ''), this) // eslint-disable-line no-console
@@ -11,9 +11,9 @@ function log(x) {
 
 let someTag = '.xyz:hover'
 
-css`opacity: 0.5`
+cssFoo`opacity: 0.5`
 
-let rule = css`
+let rule = cssFoo`
   /* real css! */
   + h1 { backgroundColor: black }
   h1.title & { color: blue }
@@ -28,7 +28,7 @@ let rule = css`
   html.ie9 & ${someTag} { padding: 300px }
 
   /* and composition  */
-  ${css`color: greenish`}
+  ${cssFoo`color: greenish`}
   --custom: --xyz;
   background-color: var(--main-bg-color, something);
   @media (min-width: 300px) {
@@ -46,6 +46,6 @@ let rule = css`
   margin: 0
 `
 
-export const App = () => <div className={css`${rule}; font-size: 10em`}>
+export const App = () => <div className={cssFoo`${rule}; font-size: 10em`}>
   ...
 </div>

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from 'react-dom'
 
-import { App } from './css'
+import { App } from './macros'
 render(<App/>,
   document.querySelector('#demo'))

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from 'react-dom'
 
-import { App } from './sketches'
+import { App } from './css'
 render(<App/>,
   document.querySelector('#demo'))

--- a/examples/macros.js
+++ b/examples/macros.js
@@ -1,7 +1,7 @@
-// inline css prop
+// macros
 
 import React from 'react'
-import { cssFor, css } from 'glamor'
+import { css as cssFoo } from '../src/macro'
 
 function log(x) {
   console.log((x || ''), this) // eslint-disable-line no-console
@@ -11,9 +11,9 @@ function log(x) {
 
 let someTag = '.xyz:hover'
 
-css`opacity: 0.5`
+cssFoo`opacity: 0.5`
 
-let rule = css`
+let rule = cssFoo`
   /* real css! */
   + h1 { backgroundColor: black }
   h1.title & { color: blue }
@@ -28,7 +28,7 @@ let rule = css`
   html.ie9 & ${someTag} { padding: 300px }
 
   /* and composition  */
-  ${css`color: greenish`}
+  ${cssFoo`color: greenish`}
   --custom: --xyz;
   background-color: var(--main-bg-color, something);
   @media (min-width: 300px) {
@@ -46,6 +46,7 @@ let rule = css`
   margin: 0
 `
 
-export const App = () => <div className={rule}>
-  ...
+export const App = () =>
+  <div className={cssFoo`${rule}; font-size: 5em`}>
+  Itsa me... <span className={cssFoo({ color: 'orange' })}>Macro!</span>
 </div>

--- a/macro.js
+++ b/macro.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/macro')

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.1",
+    "babel-macros": "^0.5.2",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-react-require": "^3.0.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",

--- a/src/babel-hoist.js
+++ b/src/babel-hoist.js
@@ -35,33 +35,33 @@ module.exports = ({ types: t }) => {
             return
           }
 
-          path.traverse(hoistVisitor(t))
+          path.traverse({
+            JSXIdentifier(path) {
+              if (path.node.name !== 'css') return
+              if (!t.isJSXAttribute(path.parent)) return // avoid elements named `css`
+
+              const expr = path.parentPath.get('value.expression')
+              if (!expr.isObjectExpression) return
+
+              if (expr.isPure()) {
+                expr.hoist()
+              }
+            },
+            CallExpression(path) {
+              let { node } = path
+              if(node.callee.name === 'css' && node.callee.type === 'Identifier') {
+                hoistCallExpression(path);
+              }
+            }
+          })
         }
       }
     }
   }
 }
 
-function hoistVisitor(t) {
-  return {
-    JSXIdentifier(path) {
-      if (path.node.name !== 'css') return
-      if (!t.isJSXAttribute(path.parent)) return // avoid elements named `css`
-
-      const expr = path.parentPath.get('value.expression')
-      if (!expr.isObjectExpression) return
-
-      if (expr.isPure()) {
-        expr.hoist()
-      }
-    },
-    CallExpression(path) {
-      let { node } = path
-      if(node.callee.name === 'css' && node.callee.type === 'Identifier') {
-        path.get('arguments').forEach(x => x.isPure() && x.hoist())
-      }
-    }
-  }
+function hoistCallExpression(path) {
+  path.get('arguments').forEach(x => x.isPure() && x.hoist())
 }
 
-module.exports.hoistVisitor = hoistVisitor;
+module.exports.hoistCallExpression = hoistCallExpression;

--- a/src/babel-hoist.js
+++ b/src/babel-hoist.js
@@ -50,7 +50,7 @@ module.exports = ({ types: t }) => {
             CallExpression(path) {
               let { node } = path
               if(node.callee.name === 'css' && node.callee.type === 'Identifier') {
-                hoistCallExpression(path);
+                hoistCallExpressionArguments(path);
               }
             }
           })
@@ -60,8 +60,8 @@ module.exports = ({ types: t }) => {
   }
 }
 
-function hoistCallExpression(path) {
+function hoistCallExpressionArguments(path) {
   path.get('arguments').forEach(x => x.isPure() && x.hoist())
 }
 
-module.exports.hoistCallExpression = hoistCallExpression;
+module.exports.hoistCallExpressionArguments = hoistCallExpressionArguments;

--- a/src/css/babel.js
+++ b/src/css/babel.js
@@ -158,9 +158,7 @@ module.exports = {
       let code = path.hub.file.code
 
       if(tag.name === 'css') {
-        let { parsed, stubs } = parser(path)
-        let newSrc = 'css(' + convert(parsed, { stubs }) + ')'
-        path.replaceWithSourceString(newSrc)
+        convertCSSTaggedTemplateExpression(path, 'css')
       }
       else if(tag.type === 'CallExpression' && tag.callee.name === 'styled') {
         let { parsed, stubs } = parser(path)

--- a/src/macro.js
+++ b/src/macro.js
@@ -23,7 +23,16 @@ module.exports = function macro({ references, babel }) {
     });
 
     if (parentPath.type === 'CallExpression') {
+      if (parentPath.parentPath.parentPath.type === 'VariableDeclaration') {
+        addLabel(t, parentPath, parentPath.parentPath.get('id').node.name);
+      }
       hoistCallExpressionArguments(parentPath);
     }
   });
+}
+
+function addLabel(t, path, labelName) {
+  path.node.arguments.unshift(t.objectExpression([
+    t.objectProperty(t.identifier('label'), t.stringLiteral(labelName))
+  ]));
 }

--- a/src/macro.js
+++ b/src/macro.js
@@ -1,5 +1,5 @@
 const { convertCSSTaggedTemplateExpression } = require('./css/babel');
-const { hoistCallExpression } = require('./babel-hoist');
+const { hoistCallExpressionArguments } = require('./babel-hoist');
 
 module.exports = function macro({ references, babel }) {
   const firstReference = references.css[0];
@@ -23,7 +23,7 @@ module.exports = function macro({ references, babel }) {
     });
 
     if (parentPath.type === 'CallExpression') {
-      hoistCallExpression(parentPath);
+      hoistCallExpressionArguments(parentPath);
     }
   });
 }

--- a/src/macro.js
+++ b/src/macro.js
@@ -1,0 +1,21 @@
+const css = require('./css/babel');
+const hoist = require('./babel-hoist');
+
+module.exports = function macro({ references, babel }) {
+  const program = references.css[0].findParent((path) => path.type === 'Program');
+
+  const { types: t } = babel;
+  const importSpecifier = t.importSpecifier(t.identifier('css'), t.identifier('css'));
+  const importDeclaration = t.importDeclaration([importSpecifier], t.stringLiteral('glamor'));
+  program.unshiftContainer('body', importDeclaration);
+
+  const hoistVisitor = hoist.hoistVisitor(t);
+
+  references.css.forEach((path) => {
+    path.parentPath.parentPath.traverse(css.visitor);
+
+    // if (process.env.NODE_ENV === 'production') {
+      path.parentPath.parentPath.traverse(hoistVisitor);
+    // }
+  });
+}

--- a/src/macro.js
+++ b/src/macro.js
@@ -1,21 +1,29 @@
-const css = require('./css/babel');
-const hoist = require('./babel-hoist');
+const { convertCSSTaggedTemplateExpression } = require('./css/babel');
+const { hoistCallExpression } = require('./babel-hoist');
 
 module.exports = function macro({ references, babel }) {
-  const program = references.css[0].findParent((path) => path.type === 'Program');
+  const firstReference = references.css[0];
+  if (!firstReference) return;
+
+  const program = firstReference.findParent((path) => path.type === 'Program');
 
   const { types: t } = babel;
-  const importSpecifier = t.importSpecifier(t.identifier('css'), t.identifier('css'));
+
+  const importSpecifier = t.importSpecifier(t.identifier(firstReference.node.name), t.identifier('css'));
   const importDeclaration = t.importDeclaration([importSpecifier], t.stringLiteral('glamor'));
   program.unshiftContainer('body', importDeclaration);
 
-  const hoistVisitor = hoist.hoistVisitor(t);
-
   references.css.forEach((path) => {
-    path.parentPath.parentPath.traverse(css.visitor);
+    const parentPath = path.parentPath;
 
-    // if (process.env.NODE_ENV === 'production') {
-      path.parentPath.parentPath.traverse(hoistVisitor);
-    // }
+    parentPath.parentPath.traverse({
+      TaggedTemplateExpression(p) {
+        convertCSSTaggedTemplateExpression(p, path.node.name);
+      }
+    });
+
+    if (parentPath.type === 'CallExpression') {
+      hoistCallExpression(parentPath);
+    }
   });
 }

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -11,12 +11,12 @@ module.exports = {
       test: /\.js$/,
       exclude: /node_modules/,
       loader: 'babel-loader',
-      query: {
-        plugins: [ 
-          path.join(__dirname, '../src/css/babel.js')
-        ]
-      }
-    } ]  
+      // query: {
+      //   plugins: [
+      //     path.join(__dirname, '../src/css/babel.js')
+      //   ]
+      // }
+    } ]
   },
   resolve: {
     alias: {
@@ -32,7 +32,7 @@ module.exports = {
     stats: 'errors-only',
     contentBase: 'examples/',
     historyApiFallback: true,
-    compress: true, 
+    compress: true,
     inline: true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,6 +498,10 @@ babel-loader@^7.1.1:
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
 
+babel-macros@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/babel-macros/-/babel-macros-0.5.2.tgz#8180d0764c5935f6c2ee0607c6a60a89719b0307"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"


### PR DESCRIPTION
This takes care of at least some of https://github.com/threepointone/glamor/issues/301.

Wanted to start playing with babel-macros so figured I'd work on adding support here.

Not sure if the usage is as intended, so maybe also pinging @kentcdodds for guidance. Especially for the way I introduce the `import` of the actual runtime. Had to reach out to program for this.

Also another question I have is _when_ to perform the hoisting, since we don't want that during development I suppose. Maybe use `process.env.NODE_ENV`? Maybe `BABEL_ENV`? Maybe babel-macros should have an env that gets passed to the macros?

One more thing, is that this won't catch the `css` attribute in JSX elements, as babel-macros only gets us the `Identifier` nodes that are the references from the macro import. I _could_ reach out to the `Program` node to perform the hoisting in the entire file, but that feels like abusing babel-macros. Maybe babel-macros should also give us 

Also needs a lots of testing, will try and see how to add some.

Even if this is still far from what you were thinking, maybe it helps a bit as a starting point for your experiments. Hope it's at least a bit helpful!