### PR TITLE
Add typings for glamor/server

### DIFF
--- a/server.d.ts
+++ b/server.d.ts
@@ -1,0 +1,13 @@
+export interface ServerRule {
+    cssText: string;
+}
+
+export interface ServerResult {
+    html: string;
+    css: string;
+    ids: string[];
+    rules: ServerRule[];
+}
+
+export function renderStatic(fn: () => string): ServerResult;
+export function renderStaticOptimized(fn: () => string): ServerResult;


### PR DESCRIPTION
As it looks like the TypeScript rewrite has been called off for now, I would like to add a few missing typings to the existing code base, namely for server-side rendering 🙂 