### PR TITLE
Bugfix/import-createPrefixer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 ## Demo Development Server
 
-* `npm start` will run a development server with the component's demo app at [http://localhost:8080](http://localhost:8080)
+* `npm run example` will run a development server with the component's demo app at [http://localhost:8080](http://localhost:8080)
 
 ## Running Tests
 

--- a/packages/glamor/src/plugins/prefix.ts
+++ b/packages/glamor/src/plugins/prefix.ts
@@ -1,4 +1,4 @@
-import * as createPrefixer from 'inline-style-prefixer/static/createPrefixer';
+import createPrefixer from 'inline-style-prefixer/static/createPrefixer';
 import { Node } from './PluginSet';
 import staticData from './prefixer-data';
 


### PR DESCRIPTION
Import of createPrefixer uses * when there's a default export present. The result is a `{ default: [Function: createPrefixer] }` vs `[Function: createPrefixer]`