### PR TITLE
Fix: Add server.d.ts to NPM bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jsxstyle.d.ts",
     "react.d.ts",
     "ous.d.ts",
+    "server.d.ts",
     "utils.d.ts"
   ],
   "scripts": {


### PR DESCRIPTION
When updating, I noticed that the TypeScript definitions for `'glamor/server'` added in #314 aren't actually included in the NPM bundle :flushed: 