### PR TITLE
Add box.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lib",
     "umd",
     "aphrodite.js",
+    "box.js",
     "jsxstyle.js",
     "babel.js",
     "babel-hoist.js",

--- a/src/box.js
+++ b/src/box.js
@@ -1,9 +1,9 @@
 import { css } from './index';
 import React from 'react';
 
-const Box = ({ css: cssProp, component, ...props }) => {
+const Box = ({ css: cssProp, component, innerRef, ...props }) => {
   const Component = component || 'div';
-  return <Component {...css(cssProp)} {...props} />;
+  return <Component ref={innerRef} {...css(cssProp)} {...props} />;
 };
 
 export default Box;

--- a/src/box.js
+++ b/src/box.js
@@ -1,0 +1,9 @@
+import { css } from './index';
+import React from 'react';
+
+const Box = ({ css: cssProp, component, ...props }) => {
+  const Component = component || 'div';
+  return <Component {...css(cssProp)} {...props} />;
+};
+
+export default Box;


### PR DESCRIPTION
This way people with no access to modifying babel settings can use 
```js 
import Box from 'glamor/box';

const Heading = props =>
    <Box component="h2" css={{fontSize: 12, ...props.css}}>
        Hello World
    </Box>
```
out of the box.