### PR TITLE
Replace murmur hash with faster hash method

### DIFF
--- a/src/hash.js
+++ b/src/hash.js
@@ -1,68 +1,10 @@
-// murmurhash2 via https://gist.github.com/raycmorgan/588423
+// https://github.com/darkskyapp/string-hash
 
-export default function doHash(str, seed) {
-  let m = 0x5bd1e995
-  let r = 24
-  let h = seed ^ str.length
-  let length = str.length
-  let currentIndex = 0
-
-  while (length >= 4) {
-    let k = UInt32(str, currentIndex)
-
-    k = Umul32(k, m)
-    k ^= k >>> r
-    k = Umul32(k, m)
-
-    h = Umul32(h, m)
-    h ^= k
-
-    currentIndex += 4
-    length -= 4
+export default function doHash(str) {
+  var hash = 5381,
+    i = str.length;
+  while(i) {
+    hash = (hash * 33) ^ str.charCodeAt(--i);
   }
-
-  switch (length) {
-    case 3:
-      h ^= UInt16(str, currentIndex)
-      h ^= str.charCodeAt(currentIndex + 2) << 16
-      h = Umul32(h, m)
-      break
-
-    case 2:
-      h ^= UInt16(str, currentIndex)
-      h = Umul32(h, m)
-      break
-
-    case 1:
-      h ^= str.charCodeAt(currentIndex)
-      h = Umul32(h, m)
-      break
-  }
-
-  h ^= h >>> 13
-  h = Umul32(h, m)
-  h ^= h >>> 15
-
-  return h >>> 0
-}
-
-function UInt32(str, pos) {
-  return (str.charCodeAt(pos++)) +
-         (str.charCodeAt(pos++) << 8) +
-         (str.charCodeAt(pos++) << 16) +
-         (str.charCodeAt(pos) << 24)
-}
-
-function UInt16(str, pos) {
-  return (str.charCodeAt(pos++)) +
-         (str.charCodeAt(pos++) << 8)
-}
-
-function Umul32(n, m) {
-  n = n | 0
-  m = m | 0
-  let nlo = n & 0xffff
-  let nhi = n >>> 16
-  let res = ((nlo * m) + (((nhi * m) & 0xffff) << 16)) | 0
-  return res
+  return hash >>> 0;
 }


### PR DESCRIPTION
As discussed in issues of this project and with similar emotion project collaborators, the murmur hash function is very slow and for the needs of this project can be replaced with faster hash.
The provided function is tested on real enterprise project also and provides up to 4 billion unique hashes