### PR TITLE
Failing test and proposed fix for css({'data-css-nil': ''})

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -358,7 +358,7 @@ function build(dest, { selector = '', mq = '', supp = '', src = {} }) {
   src = flatten(src)
 
   src.forEach(_src => {
-    if(isLikeRule(_src)) {
+    if(isLikeRule(_src) && idFor(_src) !== 'nil') {
       let reg = _getRegistered(_src)
       if(reg.type !== 'css') { throw new Error('cannot merge this rule') }
       _src = reg.style

--- a/src/index.js
+++ b/src/index.js
@@ -358,7 +358,10 @@ function build(dest, { selector = '', mq = '', supp = '', src = {} }) {
   src = flatten(src)
 
   src.forEach(_src => {
-    if(isLikeRule(_src) && idFor(_src) !== 'nil') {
+    if(isLikeRule(_src)) {
+      if(idFor(_src) === 'nil') {
+        return
+      }
       let reg = _getRegistered(_src)
       if(reg.type !== 'css') { throw new Error('cannot merge this rule') }
       _src = reg.style

--- a/tests/index.js
+++ b/tests/index.js
@@ -877,7 +877,11 @@ describe('css', () => {
         { '&&': { 'color': 'browner' } } 
       ] }
     ])
-    
+
+  })
+
+  it('can handle data-css-nil nullrule', () => {
+    let rule = css({'data-css-nil': ''})
   })
 })
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -882,6 +882,9 @@ describe('css', () => {
 
   it('can handle data-css-nil nullrule', () => {
     let rule = css({'data-css-nil': ''})
+    expect(rule).toEqual({
+      'data-css-1268me8': ''
+    })
   })
 })
 


### PR DESCRIPTION
I can't see any documentation or explanation in the code as to what `data-css-nil` is for, other than:

https://github.com/threepointone/glamor/blob/db533d7c5fe249e443756367161d0830086b0624/src/index.js#L430-L432

...and some perhaps related discussion in issue #303.

However, Glamorous, under certain conditions, will call `css({'data-css-nil': ''})`, which causes Glamor to throw the following error:

>  Error: [glamor] an unexpected rule cache miss occurred. This is probably a sign of multiple glamor instances in your app. See https://github.com/threepointone/glamor/issues/79

See:

paypal/glamorous#396
paypal/glamorous#397

I am not sure if this bug is due to Glamorous sending something through that it shouldn't, or Glamor not handling this correctly, so have created failing tests for both scenarios.

I can't find references to `data-css-nil` in Glamorous' code base but can continue to debug to try find out what's causing this. However if anyone has any insight on this that may save a lot of code reading then please let me know 🙂