### PR TITLE
Use csstype for a baseline of CSS definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,12 @@
-export interface CSSProperties {
+import * as CSS from 'csstype';
+
+export interface CSSProperties extends CSS.Properties<number | string> {
   /**
    * In dev mode, adding a `label` string prop will reflect its value in devtools. Useful
    * when debugging, and a good alternative to 'semantic' classnames.
    */
   label?: string;
-  // for now just allow everything
+  // for now just allow everything as a fallback
   [propertyName: string]: any;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,6 @@ export interface CSSProperties extends CSS.Properties<number | string> {
    * when debugging, and a good alternative to 'semantic' classnames.
    */
   label?: string;
-  // for now just allow everything as a fallback
-  [propertyName: string]: any;
 }
 
 export interface StyleAttribute {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     }
   },
   "dependencies": {
-    "csstype": "^2.0.0",
+    "csstype": "^2.4.0",
     "fbjs": "^0.8.12",
     "inline-style-prefixer": "^3.0.6",
     "object-assign": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     }
   },
   "dependencies": {
+    "csstype": "^2.0.0",
     "fbjs": "^0.8.12",
     "inline-style-prefixer": "^3.0.6",
     "object-assign": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,6 +1721,10 @@ css-in-js-utils@^1.0.3:
   dependencies:
     hyphenate-style-name "^1.0.2"
 
+csstype@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.0.0.tgz#7d199dd8dca409077e81569eca0c71a74c4f4158"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,9 +1721,9 @@ css-in-js-utils@^1.0.3:
   dependencies:
     hyphenate-style-name "^1.0.2"
 
-csstype@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.0.0.tgz#7d199dd8dca409077e81569eca0c71a74c4f4158"
+csstype@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.4.0.tgz#6c7d711cc135dcd90c812a80213eab006fc1acff"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
[`csstype`](https://github.com/frenic/csstype) is a set of standard, high-quality CSS typings generated from MDN data. It is now being used by the React and JSS typings. It would be great to have the entire CSS-in-JS ecosystem standardize on these typings!