### PR TITLE
Fix typo in docs/howto Combined selectors

### DIFF
--- a/docs/howto.md
+++ b/docs/howto.md
@@ -443,5 +443,5 @@ const f1Red = style({
 });
 
 // ...but you still have to use all three selectors
-<div class={`${f1} ${red} ${f1red}`}></div>
+<div class={`${f1} ${red} ${f1Red}`}></div>
 ```


### PR DESCRIPTION
In the docs/howto Combined selectors guide, the line when apply the css should reference to `f1Red` instead of `f1red`, though it's so obviously 😭 