### PR TITLE
Generalize type for html in ServerResults typescript definition

### DIFF
--- a/server.d.ts
+++ b/server.d.ts
@@ -1,13 +1,17 @@
+export type HTMLType = string | NodeJS.ReadableStream;
+
 export interface ServerRule {
-    cssText: string;
+  cssText: string;
 }
 
-export interface ServerResult {
-    html: string;
-    css: string;
-    ids: string[];
-    rules: ServerRule[];
+export interface ServerResult<T extends HTMLType> {
+  html: T;
+  css: string;
+  ids: string[];
+  rules: ServerRule[];
 }
 
-export function renderStatic(fn: () => string): ServerResult;
-export function renderStaticOptimized(fn: () => string): ServerResult;
+export function renderStatic<T extends HTMLType>(fn: () => T): ServerResult<T>;
+export function renderStaticOptimized<T extends HTMLType>(
+  fn: () => string
+): ServerResult<T>;


### PR DESCRIPTION
Since ReactDOM can now render to a readable stream, this will let us properly return that as the type for the HTML value.

ie)

```tsx
    const { html, css } = renderStatic(() => renderToNodeStream(app));

    ctx.respond = false;
    ctx.status = 200;
    ctx.res.write(
      '<!doctype html>' +
        '<html lang="en">' +
        '<head>' +
        `<style>${css}</style>` +
        '</head>' +
        '<body>' +
        '<main id="app">',
    );

    html
      .on('end', () => {
        ctx.res.end(
          '</main>' +
            '</body>' +
            '</html>',
        );
      })
      .pipe(ctx.res);
  };
```