### PR TITLE
Use current version of inline-style-prefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "dependencies": {
     "fbjs": "^0.8.12",
-    "inline-style-prefixer": "^3.0.6",
+    "inline-style-prefixer": "^6.0.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.5.10",
     "through": "^2.3.8"

--- a/src/prefixer.js
+++ b/src/prefixer.js
@@ -1,21 +1,21 @@
 // custom facade for inline-style-prefixer
 
-import staticData from 'inline-style-prefixer/static/staticData'
+import staticData from 'inline-style-prefixer/lib/data'
 
-import prefixProperty from 'inline-style-prefixer/utils/prefixProperty'
-import prefixValue from 'inline-style-prefixer/utils/prefixValue'
+import prefixProperty from 'inline-style-prefixer/lib/utils/prefixProperty'
+import prefixValue from 'inline-style-prefixer/lib/utils/prefixValue'
 
 
-import cursor from 'inline-style-prefixer/static/plugins/cursor'
-import crossFade from 'inline-style-prefixer/static/plugins/crossFade'
-import filter from 'inline-style-prefixer/static/plugins/filter'
-import flex from 'inline-style-prefixer/static/plugins/flex'
-import flexboxOld from 'inline-style-prefixer/static/plugins/flexboxOld'
-import gradient from 'inline-style-prefixer/static/plugins/gradient'
-import imageSet from 'inline-style-prefixer/static/plugins/imageSet'
-import position from 'inline-style-prefixer/static/plugins/position'
-import sizing from 'inline-style-prefixer/static/plugins/sizing'
-import transition from 'inline-style-prefixer/static/plugins/transition'
+import cursor from 'inline-style-prefixer/lib/plugins/cursor'
+import crossFade from 'inline-style-prefixer/lib/plugins/crossFade'
+import filter from 'inline-style-prefixer/lib/plugins/filter'
+import flex from 'inline-style-prefixer/lib/plugins/flex'
+import flexboxOld from 'inline-style-prefixer/lib/plugins/flexboxOld'
+import gradient from 'inline-style-prefixer/lib/plugins/gradient'
+import imageSet from 'inline-style-prefixer/lib/plugins/imageSet'
+import position from 'inline-style-prefixer/lib/plugins/position'
+import sizing from 'inline-style-prefixer/lib/plugins/sizing'
+import transition from 'inline-style-prefixer/lib/plugins/transition'
 
 const plugins = [
   crossFade,


### PR DESCRIPTION
This crosses the v5.0.0 version, which required some changes to the import paths. All tests still pass.

It turns out crossing this threshold is important for us, because we depend on libraries that depend on post-5.0.0 versions of inline-style-prefixer, and the two versions are incompatible. Node resolves this by allowing multiple versions of a single package in the same project. But we're running this code in browsers, and we're constrained to using a bundler that doesn't support multiple versions. So if we can bump this library to use a post-5.0.0 version, all uses will be compatible.